### PR TITLE
Add support for identifying "Pig Observer" stream types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 gs-creds.json
 twitter-creds.json
+
+.idea

--- a/index.js
+++ b/index.js
@@ -129,6 +129,8 @@ function checkForStream(url) {
     return checkPeriscopeLive
   } else if (streamType === 'Instagram') {
     return checkInstagramLive
+  } else if (streamType === 'Pig Observer') {
+    return
   }
 }
 

--- a/twitch-urls.js
+++ b/twitch-urls.js
@@ -23,6 +23,7 @@ const interestingPrefixes = [
   'www.pscp.tv',
   'www.twitch.tv',
   'twitter.com/i/broadcasts',
+  'pig.observer',
 ]
 
 const urlRe = /https?:\/\/[^ ]+/g

--- a/utils.js
+++ b/utils.js
@@ -46,6 +46,8 @@ const getStreamType = module.exports.getStreamType = function getStreamType(urlS
     return 'Periscope'
   } else if (host === 'instagram.com') {
     return 'Instagram'
+  } else if (host === 'pig.observer') {
+    return 'Pig Observer'
   }
 }
 


### PR DESCRIPTION
Seattle and some other cities use https://pig.observer for traffic cameras. This change enables `getStreamType` to label these feeds

We may want to consider the creation of a map from regexp > StreamTypeName so that we don't have to edit this logic any further