### PR TITLE
Perf improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,9 +249,17 @@ async function runUpdate() {
     await doc.loadInfo()
 
     const sheets = Object.values(doc.sheetsById).filter(s => tabNames.includes(s.title))
+    const processedLinks = new Set()
     for (const sheet of sheets) {
       const rows = await sheet.getRows()
       for (const [offset, row] of reverseEntries(rows)) {
+        // Skip duplicates
+        if(processedLinks.has(row.Link)) {
+          console.log(`Found duplicate source ${row.Link}`)
+          continue
+        }
+        processedLinks.add(row.Link)
+
         if (row.Source === '🤖 Bot enabled:' && row.Platform !== 'YES') {
           console.log('bot disabled. skipping sheet.')
           break

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const TIMEZONE = 'America/Chicago'
 const DATE_FORMAT = 'M/D/YY HH:mm:ss'
 const SLEEP_SECONDS = process.env.SLEEP_SECONDS
 
-const {sleep, getStreamType, getLinkInfo, getSheetTab} = require('./utils')
+const {sleep, getStreamType, getLinkInfo, getSheetTab, reverseEntries} = require('./utils')
 
 class CheckError extends Error {
   constructor({captcha, retryable}, ...params) {
@@ -251,7 +251,7 @@ async function runUpdate() {
     const sheets = Object.values(doc.sheetsById).filter(s => tabNames.includes(s.title))
     for (const sheet of sheets) {
       const rows = await sheet.getRows()
-      for (const [offset, row] of rows.entries()) {
+      for (const [offset, row] of reverseEntries(rows)) {
         if (row.Source === '🤖 Bot enabled:' && row.Platform !== 'YES') {
           console.log('bot disabled. skipping sheet.')
           break

--- a/utils.js
+++ b/utils.js
@@ -83,3 +83,24 @@ module.exports.getSheetTab = async function getSheetTab(creds, sheetID, tabName)
   await sheet.loadHeaderRow()
   return sheet
 }
+
+function* reverseKeys(arr) {
+  let key = arr.length - 1;
+
+  while (key >= 0) {
+    yield key;
+    key -= 1;
+  }
+}
+
+function* reverseValues(arr) {
+  for (let key of reverseKeys(arr)) {
+    yield arr[key];
+  }
+}
+
+module.exports.reverseEntries = function* reverseEntries(arr) {
+  for (let key of reverseKeys(arr)) {
+    yield [key, arr[key]];
+  }
+}


### PR DESCRIPTION
Two changes here:

1. Always process links in the livesheet last-in-first
2. Skip rows with duplicate links

There's more we could do here to prevent puppeteer from having to open all of the time, but this has been enough to make a dent in the perf. issues for us.